### PR TITLE
Fix status_label

### DIFF
--- a/lib/redmine_stealth.rb
+++ b/lib/redmine_stealth.rb
@@ -5,7 +5,7 @@ module RedmineStealth
   module_function
 
   def status_label(is_activateed)
-    is_activateed ? l(:enable_stealth_mode) : l(:disable_stealth_mode)
+    is_activateed ? l(:disable_stealth_mode) : l(:enable_stealth_mode)
   end
 
   def javascript_toggle_statement(is_activateed)


### PR DESCRIPTION
hi!

[teleological/redmine_stealth](https://github.com/teleological/redmine_stealth) see not to be maintained, so I will PR here.

I think that `enable_stealth_mode` and `disable_stealth_mode` are reversed.

```ruby
  def status_label(is_activateed)
    is_activateed ? l(:enable_stealth_mode) : l(:disable_stealth_mode)
  end
```

When stealth mode is activated, Should be display `"Disable Stealth Mode"`.
Likewise, when stealth mode is deactivated, Should be display `"Enable Stealth Mode"`.